### PR TITLE
register custom event for OrientationChange event to avoid app crash with unsupported top level event type error

### DIFF
--- a/ios/RNModalNoUnmountManager.m
+++ b/ios/RNModalNoUnmountManager.m
@@ -32,6 +32,8 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(onOrientationChange, RCTDirectEventBlock)
 
 @end
+
   


### PR DESCRIPTION
Fix #1 